### PR TITLE
Protocol Parser should allow for code to be provided before the decode is invoked

### DIFF
--- a/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Grammar.java
+++ b/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Grammar.java
@@ -17,6 +17,7 @@ public class Grammar {
    String simpleName;
    String baseClassName;
    RuleDefinition root;
+   Action beforeDecodeAction;
    Action initAction;
    Action exceptionally;
    Action deadEnd;
@@ -37,7 +38,9 @@ public class Grammar {
       Machine machine = new Machine(pkg, simpleName, baseClassName,
             initAction == null ? null : initAction.code(this),
             exceptionally == null ? null : exceptionally.code(this),
-            deadEnd == null ? null : deadEnd.code(this), maxSwitchStates, userSwitchThreshold, passContext);
+            deadEnd == null ? null : deadEnd.code(this),
+            beforeDecodeAction == null ? null : beforeDecodeAction.code(this),
+            maxSwitchStates, userSwitchThreshold, passContext);
       imports.forEach(machine::addImport);
 
       for (RuleDefinition rule : rules) {

--- a/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Machine.java
+++ b/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Machine.java
@@ -18,19 +18,22 @@ public class Machine {
    private final String initAction;
    private final String exceptionally;
    private final String deadEnd;
+   private final String beforeDecode;
    private final int maxSwitchStates;
    private final int userSwitchThreshold;
    private final int switchShift;
    private final boolean passContext;
    private List<State> states = new ArrayList<>();
 
-   public Machine(String pkg, String simpleName, String baseClassName, String initAction, String exceptionally, String deadEnd, int maxSwitchStates, int userSwitchThreshold, boolean passContext) {
+   public Machine(String pkg, String simpleName, String baseClassName, String initAction, String exceptionally,
+         String deadEnd, String beforeDecode, int maxSwitchStates, int userSwitchThreshold, boolean passContext) {
       this.pkg = pkg;
       this.simpleName = simpleName;
       this.baseClassName = baseClassName;
       this.initAction = initAction;
       this.exceptionally = exceptionally;
       this.deadEnd = deadEnd;
+      this.beforeDecode = beforeDecode;
       this.maxSwitchStates = Integer.highestOneBit(maxSwitchStates - 1) << 1;
       this.userSwitchThreshold = userSwitchThreshold;
       this.switchShift = 32 - Integer.numberOfLeadingZeros(maxSwitchStates - 1);
@@ -74,6 +77,9 @@ public class Machine {
       sb.append("\tpublic void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> out) throws Exception {\n");
       sb.append("\t\tint pos = buf.readerIndex();\n");
       sb.append("\t\ttry {\n");
+      if (beforeDecode != null) {
+         sb.append(prettyPrint(beforeDecode, 3)).append("\n");
+      }
       sb.append("\t\t\twhile (switch").append(numLevels > 1 ? (numLevels - 1) + "_" : "").append("0(");
       if (passContext) sb.append("ctx, ");
       sb.append("buf));\n");

--- a/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Parser.java
+++ b/protocol-parser-generator/src/main/java/org/infinispan/ppg/generator/Parser.java
@@ -107,6 +107,10 @@ public class Parser {
                parse(new File(file.getParentFile(), f), true);
                expectSemicolon(ctx);
                break;
+            case "beforedecode":
+               ctx.next("{");
+               grammar.beforeDecodeAction = new Action(ctx.ns, processCode(ctx), ctx.file, ctx.line);
+               break;
             case "init":
                ctx.next("{");
                grammar.initAction = new Action(ctx.ns, processCode(ctx), ctx.file, ctx.line);


### PR DESCRIPTION
Adds a new known block type in the protocol parser generator.

This allows for a new code block to be specified that is added automatically in the try block just before invoking decode. This can be useful to add something like below, which only invokes decode if auto read is enabled.

```example.gr
beforedecode {
   // We cannot read more than one command at a time
   if (!ctx.channel().config().isAutoRead()) { return; }
}
```

```result.java
	@Override
	public void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> out) throws Exception {
		int pos = buf.readerIndex();
		try {
   		   if (! ctx.channel().config().isAutoRead()) {
		   	return;
		   }
		   while (switch0(ctx, buf));
		} catch (Throwable t) {
		   throw t;
		} finally {
		   requestBytes += buf.readerIndex() - pos;
		}
	}
```