### PR TITLE
Prevent commit proto lock warning

### DIFF
--- a/Jenkinsfile-release
+++ b/Jenkinsfile-release
@@ -37,7 +37,7 @@ pipeline {
         stage('Deploy') {
             steps {
                 configFileProvider([configFile(fileId: 'maven-settings-with-deploy-release', variable: 'MAVEN_SETTINGS')]) {
-                    sh "$MAVEN_HOME/bin/mvn -B -V -s '$MAVEN_SETTINGS' -DskipTests clean deploy"
+                    sh "$MAVEN_HOME/bin/mvn -B -V -s '$MAVEN_SETTINGS' -Pcommunity-release -DskipTests clean deploy"
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -189,25 +189,35 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <nexusUrl>${maven.releases.nexus.url}</nexusUrl>
-                    <serverId>${maven.releases.repo.id}</serverId>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-        </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>community-release</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <nexusUrl>${maven.releases.nexus.url}</nexusUrl>
+                            <serverId>${maven.releases.repo.id}</serverId>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/proto-schema-compatibility/src/main/java/org/infinispan/plugins/proto/compatibility/ProtoCompatibilityMojo.java
+++ b/proto-schema-compatibility/src/main/java/org/infinispan/plugins/proto/compatibility/ProtoCompatibilityMojo.java
@@ -48,7 +48,7 @@ public class ProtoCompatibilityMojo extends AbstractMojo {
    @Parameter(defaultValue = "${project.build.directory}/classes/proto", readonly = true)
    private String protoSourceRoot;
 
-   @Parameter(defaultValue = "false", readonly = true)
+   @Parameter(defaultValue = "false")
    private boolean commitProtoLock;
 
    /**


### PR DESCRIPTION
Prevents:

```
[WARNING] Parameter 'commitProtoLock' is read-only, must not be used in configuration
```